### PR TITLE
Dont fail importing GenericMeta in python3.7

### DIFF
--- a/gastrodon/__init__.py
+++ b/gastrodon/__init__.py
@@ -10,7 +10,13 @@ from functools import lru_cache
 from sys import stdout,_getframe
 from types import FunctionType,LambdaType,GeneratorType,CoroutineType,FrameType,CodeType,MethodType
 from types import BuiltinFunctionType,BuiltinMethodType,DynamicClassAttribute,ModuleType,AsyncGeneratorType
-from typing import Dict,GenericMeta,Match
+from typing import Dict,Match
+try:
+    from typing import GenericMeta  # python 3.6
+except ImportError:
+    # in 3.7, genericmeta doesn't exist but we don't need it
+    # see pep-0560/
+    class GenericMeta(type): pass
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 


### PR DESCRIPTION
GenericMeta is not needed anymore in python3.7 (see PEP-560) and does
not exist anymore in the typing module.

For backward compatibilty with python3.6, the GenericMeta type is kept
in code and a `GenericMeta` class is created when the import fails.